### PR TITLE
fix toc href duplication when title starts with same word

### DIFF
--- a/assets/js/vendor/jquery.toc.js
+++ b/assets/js/vendor/jquery.toc.js
@@ -154,7 +154,7 @@
         var defaultOpts = {
             selector: 'h1, h2, h3, h4, h5, h6',
             scope: 'body',
-            overwrite: false,
+            overwrite: true,
             prefix: 'toc'
         };
 


### PR DESCRIPTION
Fix toc href duplication when title starts with same word, example like this:
![image](https://user-images.githubusercontent.com/10829171/109160782-32cacb80-77b1-11eb-8b83-389d3aca24a3.png)
